### PR TITLE
http > https

### DIFF
--- a/stat_api/stat_api.py
+++ b/stat_api/stat_api.py
@@ -69,7 +69,7 @@ class Stat(object):
 
     def _make_base_url(self, subdomain):
 
-        return "http://" + subdomain + ".getstat.com"
+        return "https://" + subdomain + ".getstat.com"
 
     def _make_api_request_url(self, endpoint):
 


### PR DESCRIPTION
getstats api returns 302 for http requests. Not valid JSON and results in an error.